### PR TITLE
Fix logging message

### DIFF
--- a/eu_climate/utils/utils.py
+++ b/eu_climate/utils/utils.py
@@ -32,7 +32,8 @@ def setup_logging(name=__name__):
     
     # Get logger for the specific module
     logger = logging.getLogger(name)
-    logger.info("Logger initialized with name: %s, %s", name, dir)
+    # Log the logger name for debugging purposes
+    logger.info("Logger initialized with name: %s", name)
     return logger
 
 


### PR DESCRIPTION
## Summary
- improve logging setup by removing stray built-in reference

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ad581bda88328af0439cf568f7a04